### PR TITLE
Download BytesIO

### DIFF
--- a/scirisweb/sw_app.py
+++ b/scirisweb/sw_app.py
@@ -4,17 +4,16 @@ sw_app.py -- classes for Sciris (Flask-based) apps
 Last update: 2018nov14
 """
 
-import logging
 # Imports
 import io
 import os
-import socket
 import sys
+import socket
+import logging
 import traceback
 from collections import OrderedDict
 from functools import wraps
 
-import matplotlib.pyplot as ppl
 from flask import Flask, request, abort, json, jsonify as flask_jsonify, send_from_directory, make_response, current_app as flaskapp, send_file
 from flask_login import LoginManager, current_user
 from flask_session import RedisSessionInterface
@@ -248,6 +247,7 @@ class ScirisApp(sc.prettyobj):
 
         # Initialize plotting
         try:
+            import matplotlib.pyplot as ppl # Place here so as not run on import
             ppl.switch_backend(self.config['MATPLOTLIB_BACKEND'])
             print('Matplotlib backend switched to "%s"' % (self.config['MATPLOTLIB_BACKEND']))
         except Exception as E:

--- a/scirisweb/sw_app.py
+++ b/scirisweb/sw_app.py
@@ -488,7 +488,7 @@ class ScirisApp(sc.prettyobj):
             # - 'bytes': a BytesIO to serve via flask.send_file
             # - 'filename': the filename to use
             if verbose: print('RPC(): Starting bytes download...')
-            response = send_file(result['bytes'], as_attachment=True,attachment_filename=result['filename'])
+            response = send_file(result['bytes'], as_attachment=True, attachment_filename=result['filename'])
             response.headers['filename'] = result['filename']
             return response
 

--- a/scirisweb/sw_app.py
+++ b/scirisweb/sw_app.py
@@ -498,7 +498,7 @@ class ScirisApp(sc.prettyobj):
                 output_name = file_name
             elif isinstance(result,io.BytesIO):
                 from_file = False
-                bytes = result
+                bytesio = result
                 output_name = 'download.obj'
             else:
                 try:
@@ -509,7 +509,7 @@ class ScirisApp(sc.prettyobj):
                         dir_name, file_name = os.path.split(content)
                     elif isinstance(content,io.BytesIO):
                         from_file = False
-                        bytes = content
+                        bytesio = content
                     else:
                         return robustjsonify({'error': 'Unrecognized RPC output'})
                 except Exception as E:
@@ -522,7 +522,7 @@ class ScirisApp(sc.prettyobj):
                 # because it is in use during the actual download, so we rely on
                 # later cleanup to remove download files.
             else:
-                response = send_file(bytes, as_attachment=True, attachment_filename=output_name)
+                response = send_file(bytesio, as_attachment=True, attachment_filename=output_name)
             response.headers['filename'] = output_name
             print(response)
             return response # Return the response message.

--- a/scirisweb/sw_version.py
+++ b/scirisweb/sw_version.py
@@ -1,5 +1,5 @@
 __all__ = ['__version__', '__versiondate__', '__license__']
 
-__version__      = '0.12.7'
-__versiondate__  = '2019-05-23'
+__version__      = '0.12.8'
+__versiondate__  = '2019-06-04'
 __license__      = 'ScirisWeb %s (%s) -- (c) Sciris.org' % (__version__, __versiondate__)


### PR DESCRIPTION
This adds an RPC type `bytes_download` which serves a BytesIO file (supported natively by `flask.send_file`) which thus allows files to be served without having to write them to disk on the server. For temporary files, this means no possibility of name collisions on disk, as well as no need to worry about cleaning up the file after the download is complete. Not sure how this would perform on very large files (e.g. >100mb) but for reasonable file sizes (e.g. all reasonable Excel files) this should be fine.

Example usage:

In `.vue`

```
      downloadVersion() {
        try{
            this.$sciris.download('mf_download_version', [this.activeVersion.key]);
        } catch (error){
            this.$sciris.fail(this, 'Could not download framework file', error);
        }
      },
```

In `rpcs.py`

```
@RPC(call_type='bytes_download')
def mf_download_version(version_key):
    v = query(dbm.FrameworkFile).get(version_key)
    return {'bytes':v.spreadsheet.tofile(),'filename':'test.xlsx'}
```

Note that the `bytes_download` takes in a BytesIO and a filename explicitly rather than directly taking in a blobject, to facilitate interfacing with end-user code (e.g. if producing a BytesIO on demand for other types of pickles e.g. dataframes) but happily since `Blobject.tofile()` returns the BytesIO required, it integrates quite nicely as shown above 