### PR TITLE
Split error message and traceback

### DIFF
--- a/scirisweb/sw_tasks.py
+++ b/scirisweb/sw_tasks.py
@@ -59,7 +59,8 @@ class Task(sc.prettyobj):
         self.task_id        = task_id # Set the task ID (what the client typically knows as the task).
         self.uid            = task_id # Make it the same as the task ID...WARNING, fix
         self.status         = 'unknown' # Start the status at 'unknown'.
-        self.error_text     = None # Start the error_text at None.
+        self.error_msg      = None # Start the error_msg at None.
+        self.error_traceback= None # Start the error_traceback at None.
         self.func_name      = None # Start the func_name at None.
         self.args           = None # Start the args and kwargs at None.
         self.kwargs         = None
@@ -75,7 +76,8 @@ class Task(sc.prettyobj):
         print('-----------------------------')
         print('        Task ID: %s'   % self.task_id)
         print('         Status: %s'   % self.status)
-        print('     Error text: %s'   % self.error_text)
+        print('      Error msg: %s'   % self.error_msg)
+        print('Error traceback: %s'   % self.error_traceback)
         print('  Function name: %s'   % self.func_name)
         print('  Function args: %s'   % self.args)
         print('Function kwargs: %s'   % self.kwargs)        
@@ -86,13 +88,14 @@ class Task(sc.prettyobj):
         print('   Pending time: %s s' % self.pending_time)        
         print(' Execution time: %s s' % self.execution_time)  
         print('-----------------------------')
-    
+
     def jsonify(self):
         output = {'task':
                      {'UID':           self.uid,                    
                       'taskId':        self.task_id,
                       'status':        self.status,
-                      'errorText':     self.error_text,
+                      'errorMsg':      self.error_msg,
+                      'errorTraceback':self.error_traceback,
                       'funcName':      self.func_name,
                       'funcArgs':      self.args,
                       'funcKwargs':    self.kwargs,
@@ -106,6 +109,14 @@ class Task(sc.prettyobj):
                   }
         return output
 
+    def __setstate__(self, state):
+
+        ### Migration for changing errorText to errorMsg+errorTraceback
+        if 'error_msg' not in state:
+            state['error_msg'] = 'Error occured - please check console'
+            state['error_traceback'] = state['error_traceback']
+            
+        self.__dict__ = state
 
 
 ################################################################################
@@ -204,11 +215,12 @@ def make_celery(config=None, verbose=True):
             result = task_func_dict[func_name](*args, **kwargs)
             match_taskrec.status = 'completed'
             if verbose: print('C>> Successfully completed task %s! :)' % task_id)
-        except Exception: # If there's an exception, grab the stack track and set the TaskRecord to have stopped on in error.
-            error_text = traceback.format_exc()
+        except Exception as e: # If there's an exception, grab the stack track and set the TaskRecord to have stopped on in error.
+            error_traceback = traceback.format_exc()
             match_taskrec.status = 'error'
-            match_taskrec.error_text = error_text
-            result = error_text
+            match_taskrec.error_traceback = error_traceback
+            match_taskrec.error_msg = str(e)
+            result = error_traceback
             if verbose: print('C>> Failed task %s! :(' % task_id)
         
         # Set the TaskRecord to indicate end of the task.
@@ -225,12 +237,13 @@ def make_celery(config=None, verbose=True):
         # which is a good thing because that could disrupt actiities in other 
         # run_task() instances.
         try:
-            datastore.savetask(match_taskrec)         
-        except Exception:
-            error_text = traceback.format_exc()
+            datastore.savetask(match_taskrec)
+        except Exception as e:  # If there's an exception, grab the stack track and set the TaskRecord to have stopped on in error.
+            error_traceback = traceback.format_exc()
             match_taskrec.status = 'error'
-            match_taskrec.error_text = error_text
-            result = error_text
+            match_taskrec.error_traceback = error_traceback
+            match_taskrec.error_msg = str(e)
+            result = error_traceback
             if verbose: print('C>> Failed to save task %s! :(' % task_id)            
             
         if verbose: print('C>> End of run_task() for %s' % task_id)

--- a/scirisweb/sw_tasks.py
+++ b/scirisweb/sw_tasks.py
@@ -60,7 +60,7 @@ class Task(sc.prettyobj):
         self.uid            = task_id # Make it the same as the task ID...WARNING, fix
         self.status         = 'unknown' # Start the status at 'unknown'.
         self.error_msg      = None # Start the error_msg at None.
-        self.error_traceback= None # Start the error_traceback at None.
+        self.error_text     = None # Start the error_text at None.
         self.func_name      = None # Start the func_name at None.
         self.args           = None # Start the args and kwargs at None.
         self.kwargs         = None
@@ -77,7 +77,7 @@ class Task(sc.prettyobj):
         print('        Task ID: %s'   % self.task_id)
         print('         Status: %s'   % self.status)
         print('      Error msg: %s'   % self.error_msg)
-        print('Error traceback: %s'   % self.error_traceback)
+        print('Error traceback: %s'   % self.error_text)
         print('  Function name: %s'   % self.func_name)
         print('  Function args: %s'   % self.args)
         print('Function kwargs: %s'   % self.kwargs)        
@@ -95,7 +95,7 @@ class Task(sc.prettyobj):
                       'taskId':        self.task_id,
                       'status':        self.status,
                       'errorMsg':      self.error_msg,
-                      'errorTraceback':self.error_traceback,
+                      'errorText':     self.error_text,
                       'funcName':      self.func_name,
                       'funcArgs':      self.args,
                       'funcKwargs':    self.kwargs,
@@ -111,11 +111,9 @@ class Task(sc.prettyobj):
 
     def __setstate__(self, state):
 
-        ### Migration for changing errorText to errorMsg+errorTraceback
+        ### Migration for changing errorText to errorMsg+errorText
         if 'error_msg' not in state:
             state['error_msg'] = 'Error occured - please check console'
-            state['error_traceback'] = state['error_traceback']
-            
         self.__dict__ = state
 
 
@@ -216,11 +214,11 @@ def make_celery(config=None, verbose=True):
             match_taskrec.status = 'completed'
             if verbose: print('C>> Successfully completed task %s! :)' % task_id)
         except Exception as e: # If there's an exception, grab the stack track and set the TaskRecord to have stopped on in error.
-            error_traceback = traceback.format_exc()
+            error_text = traceback.format_exc()
             match_taskrec.status = 'error'
-            match_taskrec.error_traceback = error_traceback
+            match_taskrec.error_text = error_text
             match_taskrec.error_msg = str(e)
-            result = error_traceback
+            result = error_text
             if verbose: print('C>> Failed task %s! :(' % task_id)
         
         # Set the TaskRecord to indicate end of the task.
@@ -239,11 +237,11 @@ def make_celery(config=None, verbose=True):
         try:
             datastore.savetask(match_taskrec)
         except Exception as e:  # If there's an exception, grab the stack track and set the TaskRecord to have stopped on in error.
-            error_traceback = traceback.format_exc()
+            error_text = traceback.format_exc()
             match_taskrec.status = 'error'
-            match_taskrec.error_traceback = error_traceback
+            match_taskrec.error_text = error_text
             match_taskrec.error_msg = str(e)
-            result = error_traceback
+            result = error_text
             if verbose: print('C>> Failed to save task %s! :(' % task_id)            
             
         if verbose: print('C>> End of run_task() for %s' % task_id)


### PR DESCRIPTION
This PR splits `error_text` into `error_traceback` and `error_msg`. The traceback is too long to show to users. In the `optim-errors` branch in `atomica_apps` a button is added when errors occur

![image](https://user-images.githubusercontent.com/755796/59479804-d4e93980-8e90-11e9-815c-6c2249ca53f2.png)

Pressing the buttons pops up the error message. The traceback is printed to the console. They need to be separated out because the full traceback typically exceeds the 1000 character limit on the popup.

To merge this PR, other sites (e.g. nutrition) will also need their task error printing code updated. Specifically, in `atomica_apps` in `optimization.js` it needed

```
            if (optimSummary.status === 'error') {
              optimSummary.errorMsg = result.data.task.errorMsg
              optimSummary.errorTraceback = result.data.task.errorTraceback
              console.log('Error in task: ', optimSummary.serverDatastoreId)
              console.log(result.data.task.errorTraceback)
```

where previously it just stored `errorText`. At minimum,  existing functionality can be preserved in those other codebases by simply changing any references to `errorText` to `errorTraceback`