### PR TITLE
Change duplicate temp dir creation

### DIFF
--- a/scirisweb/sw_datastore.py
+++ b/scirisweb/sw_datastore.py
@@ -383,10 +383,12 @@ class BaseDataStore(sc.prettyobj):
         self.set(settingskey, settings) # Save back to the database
         
         # Handle the temporary folder
-        if not os.path.exists(self.tempfolder):
+        try:
             os.makedirs(self.tempfolder)
             atexit.register(self._rmtempfolder) # Only register this if we've just created the temp folder
-        
+        except FileExistsError:
+            pass
+
         return settings
 
     


### PR DESCRIPTION
If multiple workers are started simultaneously (e.g. `gunicorn` starting multiple workers at the same time) then it's possible for `os.path.exists(self.tempfolder)` to be `False` but for another worker to create the folder in the meantime, resulting in a `FileExistsError`. The new code just traps this error directly and only registers the `atexit` function on the one worker that successfully creates the folder