### PR TITLE
Remove Python 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: xenial
 sudo: required
 language: python
 python:
-- '2.7'
 - '3.7'
 install: pip install tox-travis
 script: tox

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Some highlights of `scirisweb`:
 
 ## Is Sciris ready yet?
 
-**Sort of.** Sciris is available for use, but is still undergoing rapid deveopment. We expect a first stable version of Sciris to be ready in early 2019. If you would like us to let you know when it's ready, please email info@sciris.org.
+**Sort of.** Sciris is available for use, but is still undergoing rapid deveopment. We expect a first stable version of Sciris to be ready in early 2020. If you would like us to let you know when it's ready, please email info@sciris.org.
 
 
 ## Installation and run instructions
@@ -68,14 +68,12 @@ The easiest way to install Sciris is by using pip: `pip install scirisweb` (whic
 
 3. Install Redis: https://redis.io/topics/quickstart
 
-4. (Optional) Install [Anaconda Python](https://www.anaconda.com/download/) (Sciris is compatible with both Python 2 and Python 3), and make sure it's the default Python, e.g.
+4. (Optional) Install [Anaconda Python](https://www.anaconda.com/download/) (Sciris is only compatible with Python 3), and make sure it's the default Python, e.g.
 ```
 your_computer:~> python
-Python 2.7.12 |Anaconda 2.1.0 (64-bit)| (default, Jul  2 2016, 17:42:40)
-[GCC 4.4.7 20120313 (Red Hat 4.4.7-1)] on linux2
+Python 3.7.5 (default, Oct 25 2019, 15:51:11) 
+[GCC 7.3.0] :: Anaconda, Inc. on linux
 Type "help", "copyright", "credits" or "license" for more information.
-Anaconda is brought to you by Continuum Analytics.
-Please check out: http://continuum.io/thanks and https://anaconda.org
 ```
 
 5. Clone the Sciris repositories: `git clone http://github.com/sciris/sciris.git` and `git clone http://github.com/sciris/scirisweb.git`.

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ CLASSIFIERS = [
     'Programming Language :: Python',
     'Topic :: Software Development :: Libraries :: Python Modules',
     'Development Status :: 4 - Beta',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.7',
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py37
+envlist = py37
 
 [testenv]
 description = Run basic usage tests


### PR DESCRIPTION
Python 2.7 support was removed from Sciris so needs to be removed from ScirisWeb as well.