### PR TITLE
Add extra validation

### DIFF
--- a/scirisweb/sw_app.py
+++ b/scirisweb/sw_app.py
@@ -424,6 +424,9 @@ class ScirisApp(sc.prettyobj):
             print('   kwargs: %s' % kwargs)
         
         # If the function name is not in the RPC dictionary, return an error.
+        if not sc.isstring(fn_name) :
+            return robustjsonify({'error': 'Invalid RPC - must be a string (%s)' % fn_name})
+
         if not fn_name in self.RPC_dict:
             return robustjsonify({'error': 'Could not find requested RPC "%s"' % fn_name})
         


### PR DESCRIPTION
If the RPC name is `undefined` in the POST request, then the RPC call fails with a `TypeError` in Python. However, this doesn't return an error state back to the FE, so the promise just hangs on the FE. This PR catches that error and returns a message to the user - it should only ever be encountered during development